### PR TITLE
build: install all contrib scripts

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -104,9 +104,10 @@ install_data(
     install_dir: join_paths(get_option('datadir'), 'xdg-desktop-portal', 'portals'),
 )
 
-install_data(
-    'contrib/ranger-wrapper.sh',
+install_subdir(
+    'contrib',
     install_dir: join_paths(get_option('datadir'), 'xdg-desktop-portal-termfilechooser'),
+    strip_directory: true,
 )
 
 scdoc = dependency('scdoc', required: get_option('man-pages'), version: '>= 1.9.7')


### PR DESCRIPTION
Hi. What do you think of making this repo the new active fork, since you seem to be invested. I'd like to use all your patches and it would be easier to have them all on the same branch

This PR fixes the meson build to copy all contrib scripts, not only the ranger wrapper